### PR TITLE
[fix] Repository address

### DIFF
--- a/packages/modal-enhanced-react-native-web/package.json
+++ b/packages/modal-enhanced-react-native-web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.9",
   "description": "React native modal enhanced for web",
   "main": "dist/index.js",
-  "repository": "https://github.com/rayandrews/react-native-web-modal/packages/modal-enhanced-react-native-web",
+  "repository": "https://github.com/Dekoruma/react-native-web-modal/tree/master/packages/modal-enhanced-react-native-web",
   "author": "Ray Andrew <raydreww@gmail.com>",
   "license": "MIT",
   "private": false,

--- a/packages/modal-react-native-web/package.json
+++ b/packages/modal-react-native-web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.9",
   "description": "React native modal implementation for web",
   "main": "dist/index.js",
-  "repository": "https://github.com/Dekoruma/react-native-web-modal/packages/modal-react-native-web",
+  "repository": "https://github.com/Dekoruma/react-native-web-modal/tree/master/packages/modal-react-native-web",
   "author": "Ray Andrew <raydreww@gmail.com>",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
The current repository address in each `package.json` resolves to a 404
on GitHub. This updates each package's `package.json` to point to the
master branch of the repository.