### PR TITLE
Fix for when the component is unmounted quickly

### DIFF
--- a/packages/modal-react-native-web/src/Portal.js
+++ b/packages/modal-react-native-web/src/Portal.js
@@ -22,7 +22,7 @@ export default class Portal extends Component {
   }
 
   componentWillUnmount() {
-    this.state.target.removeChild(this.state.el);
+    this.state.target && this.state.target.removeChild(this.state.el);
   }
 
   render() {


### PR DESCRIPTION
Fix for when the component is unmounted quickly. the callback of the setstate in componentDidMount is called after the componentWillUnmount, hence the componentWillUnmount results in an error.