### PR TITLE
Add support to modify the backdrop style

### DIFF
--- a/packages/modal-enhanced-react-native-web/package.json
+++ b/packages/modal-enhanced-react-native-web/package.json
@@ -49,5 +49,8 @@
     "react-art": "16.x.x",
     "react-dom": "16.x.x",
     "react-native-web": "0.9.x"
+  },
+  "dependencies": {
+    "modal-react-native-web": "^0.2.0"
   }
 }

--- a/packages/modal-enhanced-react-native-web/package.json
+++ b/packages/modal-enhanced-react-native-web/package.json
@@ -49,8 +49,5 @@
     "react-art": "16.x.x",
     "react-dom": "16.x.x",
     "react-native-web": "0.9.x"
-  },
-  "dependencies": {
-    "modal-react-native-web": "^0.2.0"
   }
 }

--- a/packages/modal-enhanced-react-native-web/src/index.js
+++ b/packages/modal-enhanced-react-native-web/src/index.js
@@ -97,6 +97,7 @@ class ReactNativeModal extends Component {
     scrollTo: null,
     scrollOffset: 0,
     scrollOffsetMax: 0,
+    backdropStyle: {},
   };
 
   // We use an internal state for keeping track of the modal visibility: this allows us to keep
@@ -287,8 +288,8 @@ class ReactNativeModal extends Component {
 
   // User can define custom react-native-animatable animations, see PR #72
   buildAnimations = (props) => {
-    let animationIn = props.animationIn;
-    let animationOut = props.animationOut;
+    let { animationIn } = props;
+    let { animationOut } = props;
 
     if (isObject(animationIn)) {
       const animationName = JSON.stringify(animationIn);
@@ -373,7 +374,7 @@ class ReactNativeModal extends Component {
       );
     }
 
-    let animationOut = this.animationOut;
+    let { animationOut } = this;
 
     if (this.inSwipeClosingState) {
       this.inSwipeClosingState = false;
@@ -486,6 +487,7 @@ class ReactNativeModal extends Component {
                   ? backdropColor
                   : 'transparent',
               },
+              this.props.backdropStyle,
             ]}
           />
         </TouchableWithoutFeedback>

--- a/packages/modal-enhanced-react-native-web/src/index.js
+++ b/packages/modal-enhanced-react-native-web/src/index.js
@@ -467,7 +467,6 @@ class ReactNativeModal extends Component {
         {_children}
       </View>
     );
-
     return (
       <Modal
         transparent
@@ -482,12 +481,12 @@ class ReactNativeModal extends Component {
             useNativeDriver={useNativeDriver}
             style={[
               styles.backdrop,
+              this.props.backdropStyle,
               {
                 backgroundColor: this.state.showContent
                   ? backdropColor
                   : 'transparent',
               },
-              this.props.backdropStyle,
             ]}
           />
         </TouchableWithoutFeedback>


### PR DESCRIPTION
Add support to modify the backdrop style. Sometimes we need to be able to modify our backdrop style other than the color. One of common use case was editing the `zIndex`. By default the react-native-web-modal assuming the backdrop zIndex value is 9999. we can't predict the zIndex on some application. Sometimes people passing the zIndex value more than 9999 that cause the backdrop rendered behind that component.