### PR TITLE
Upgrade "react-native-web": "~0.13.12"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "react": "^16.5.2",
     "react-art": "^16.5.2",
-    "react-native-web": "^0.9.3"
+    "react-native-web": "~0.13.12"
   },
   "devDependencies": {
     "babel-eslint": "^9.0.0",


### PR DESCRIPTION
Im getting an error:
npm ERR! Could not resolve dependency:
npm ERR! peer react-native-web@"0.9.x" from modal-react-native-web@0.2.0
npm ERR! node_modules/modal-react-native-web
npm ERR!   modal-react-native-web@"^0.2.0" from the root project

so wanted to upgrade  "react-native-web" to  "~0.13.12"